### PR TITLE
Exit code for lyrics script

### DIFF
--- a/scripts/lyrics
+++ b/scripts/lyrics
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 from argparse import ArgumentParser
 from lyricwikia import get_all_lyrics, __version__
 
@@ -17,7 +18,7 @@ def main():
         for lyrics in get_all_lyrics(args.ARTIST, args.SONG, args.separator):
             print(lyrics)
     except Exception as e:
-        print('ERROR: %s' % str(e))
+        sys.exit('ERROR: %s' % str(e))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The use of an exit code in case of lyrics not found is useful to direct the control flow when integrating in shell scripts.