### PR TITLE
Lyricwikia is now availble for Gentoo end-users in the GURU overlay

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,8 @@ Otherwise download this repository and use the ``setup.py`` file:
 
     python setup.py install
 
-It is also avaliable on the AUR for Arch Linux users: `python-lyricwikia`_
+It is also avaliable on the AUR for Arch Linux users: `python-lyricwikia`_.
+And in the `GURU overlay`_ for Gentoo Linux users as `dev-python/lyricwikia`_: ``eselect repository enable guru && emerge --sync guru && emerge lyricwikia``
 
 
 Usage
@@ -75,7 +76,7 @@ provided by the official APIs):
 - ``get_lyrics(artist, song, linesep='\n', timeout=None)``: returns a string
     that contains the lyrics of the song as provided by LyricWikia. If the
     lyrics is not found, the ``LyricsNotFound`` exception is raised.
-  
+
 - ``get_all_lyrics(artist, song, linesep='\n', timeout=None)``: returns a list
   of all the lyrics versions of the song (e.g., both the *kanji* and the
   *romaji* versions if available).  If the lyrics is not found, the
@@ -92,11 +93,13 @@ Used by
 -------
 
 - `spotify-downloader`_: download Spotify playlists with albumart and meta-tags
-- `spotify-music-videos`_: watch Youtube music videos (and lyrics) for the currently playing Spotify songs
+- `vidify`_: watch Youtube music videos (and lyrics) for the currently playing Spotify songs
 
 
 .. _LyricWikia: http://lyrics.wikia.com
 .. _PyPI: https://pypi.python.org/pypi/lyricwikia
 .. _spotify-downloader: https://github.com/ritiek/spotify-downloader
 .. _python-lyricwikia: https://aur.archlinux.org/packages/python-lyricwikia/
-.. _spotify-music-videos: https://github.com/marioortizmanero/spotify-music-videos
+.. _vidify: https://github.com/vidify/vidify
+.. _dev-python/lyricwikia: https://gpo.zugaina.org/dev-python/lyricwikia
+.. _GURU overlay: https://wiki.gentoo.org/wiki/Project:GURU


### PR DESCRIPTION
I've added lyricwikia to the GURU overlay to make it available for Gentoo Linux end-users

Also, spotify-music-videos has been renamed to vidify (@marioortizmanero ) . I fixed that as well here.